### PR TITLE
HealthPlanetに投稿されておらず、DBに登録されていなかった情報ががHealthPlanetに投稿されていたらDBに登録するよう修正

### DIFF
--- a/PostDietProgress/Model/HealthData.cs
+++ b/PostDietProgress/Model/HealthData.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace PostDietProgress.Model
 {
@@ -40,10 +41,8 @@ namespace PostDietProgress.Model
         {
             DateTime = dateTime;
 
-            foreach (var item in dic)
+            foreach (var enumVal in dic.Select(item => (HealthTag)Enum.ToObject(typeof(HealthTag), int.Parse(item.Key))))
             {
-                var enumVal = (HealthTag)Enum.ToObject(typeof(HealthTag), Int32.Parse(item.Key));
-
                 switch (enumVal)
                 {
                     case HealthTag.WEIGHT:

--- a/PostDietProgress/Service/HealthPlanetService.cs
+++ b/PostDietProgress/Service/HealthPlanetService.cs
@@ -192,7 +192,7 @@ namespace PostDietProgress.Service
             /* 取得期間From,To */
             var jst = TZConvert.GetTimeZoneInfo("Tokyo Standard Time");
             var localTime = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, jst);
-            postString.Append("from=" + localTime.AddDays(-2).ToString("yyyyMMdd") + "000000" + "&");
+            postString.Append("from=" + localTime.AddDays(-14).ToString("yyyyMMdd") + "000000" + "&");
             postString.Append("to=" + localTime.ToString("yyyyMMdd") + "235959" + "&");
             /* 取得データ */
             postString.Append("tag=6021,6022,6023,6024,6025,6026,6027,6028,6029" + "&");


### PR DESCRIPTION
HealthPlanetアプリが起動していなかったために体組成計から取得されていなかった情報が、前回実行時と今回実行時の間にHealthPlanetに登録されていた場合、Discordへの投稿はせず、DBおよびGoogleFitに登録する処理の追加。
過去14日以内のデータに対応する。